### PR TITLE
Remove pyyaml as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 git+https://github.com/simphony/simphony-metaparser.git@0.2.0#egg=simphony_metaparser
 click == 3.3
-pyyaml == 3.12
 yapf == 0.16.2
 six

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
             "simphony_metaparser >= 0.2.0",
             "click >= 3.3",
             "yapf >= 0.16",
-            "pyyaml >= 3.11",
             "six"
         ],
     packages=find_packages(),


### PR DESCRIPTION
pyyaml is now a dependency of the metaparser, not of the tools themselves